### PR TITLE
shellrc: use return instead of exit

### DIFF
--- a/cmd/shellrc.sh
+++ b/cmd/shellrc.sh
@@ -22,7 +22,7 @@ ggcode () {
 ggclone () {
 	DEST="$(ggman --no-fuzzy-filter -f "$1" ls --one)"
 	if [ "$DEST" = "" ]; then
-		ggman clone "$@" || exit $?
+		ggman clone "$@" || return $?
 		DEST="$(ggman where "$1")"
 	fi
 	echo "$DEST"


### PR DESCRIPTION
If `exit $?` is used an undesired side effect on fail is that current shell exits.